### PR TITLE
Add publisher name and description

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,8 @@
 {
   "name": "warzonemodhelper",
-  "displayName": "WarzoneModHelper",
-  "description": "",
+  "displayName": "Warzone Mod Helper",
+  "publisher": "Warzone.com",
+  "description": "Upload Warzone mods directly from your editor!",
   "version": "0.0.1",
   "engines": {
     "vscode": "^1.72.0"


### PR DESCRIPTION
The name is currently showing as "undefined_publisher" and without a description.  I've also taken the liberty to add spaces to the display name, since all my other extensions have it as well.